### PR TITLE
PR #2: Download PDF answer sheets, enforce 2 invigilators and deallocate students upon venue change

### DIFF
--- a/uctMaths/apps/competition/admin.py
+++ b/uctMaths/apps/competition/admin.py
@@ -273,8 +273,8 @@ class VenueAdmin(ImportExportModelAdmin):
 
     def response_change(self, request, obj):
         """
-        Overides method in parent class.
-        Figure out where to redirect after the 'Save' button has been pressed
+        This overides method in parent class that is in the Django files.
+        Deallocates students from the venue before figuring out where to redirect after the 'Save' button has been pressed
         when editing an existing object.
         """
         queryset = [obj]

--- a/uctMaths/apps/competition/admin.py
+++ b/uctMaths/apps/competition/admin.py
@@ -268,6 +268,17 @@ class VenueAdmin(ImportExportModelAdmin):
 
 	def write_venue_register(self, request, queryset):
 		return compadmin.output_register(queryset)
+	
+	def response_change(self, request, obj):
+		"""
+		Overides method in parent class.
+		Figure out where to redirect after the 'Save' button has been pressed
+		when editing an existing object.
+		"""
+		queryset = [obj]
+		self.deallocate(request, queryset)
+		test = super()
+		return test.response_change(request, obj) 
 
 	auto_allocate.short_description = 'Auto-allocate unallocated students to selected venue(s)' 
 	deallocate.short_description = 'Deallocate students from selected venue(s)'

--- a/uctMaths/apps/competition/compadmin.py
+++ b/uctMaths/apps/competition/compadmin.py
@@ -1274,7 +1274,7 @@ def generate_school_answer_sheets(request, school_list):
     
     response = HttpResponse(output_io.getvalue())
     if len(school_list) == 1:
-        response['Content-Disposition'] = 'inline; filename=%s'%(get_answer_sheet_name(school_list[0]))
+        response['Content-Disposition'] = 'attachment; filename=%s'%(get_answer_sheet_name(school_list[0]))
         response['Content-Type'] = 'application/pdf'
     else:
         response['Content-Disposition'] = 'attachment; filename=Answer_Sheets(%s).zip' % (timestamp_now())

--- a/uctMaths/apps/competition/interface/newstudents.html
+++ b/uctMaths/apps/competition/interface/newstudents.html
@@ -144,7 +144,7 @@
                 <tr>
                     <td><input type="text" class="invig_firstname" name="inv_firstname" value="{{invigilator.firstname}}"></td>
                     <td><input type="text" class="invig_surname" name="inv_surname" value="{{invigilator.surname}}"></td>
-                    <td><input type ="text" class="invig_phone_primary" name="inv_phone_primary" value="{{invigilator.phone_primary | cut:}}"></td>                    
+                    <td><input type ="text" class="invig_phone_primary" name="inv_phone_primary" value='{{invigilator.phone_primary | cut:" "}}'></td>                    
                     <td><input type ="text" class="invig_phone_alt" name="inv_phone_alt" value="{{invigilator.phone_alt}}"></td>
                     <td><input type ="text" class="invig_mail" name="inv_email" value="{{invigilator.email|lower}}"></td>
                     <td><input type ="text" class="invig_notes" name="inv_notes" value="{{invigilator.notes}}"></td>

--- a/uctMaths/apps/competition/interface/newstudents.html
+++ b/uctMaths/apps/competition/interface/newstudents.html
@@ -18,6 +18,12 @@
         <p>Not working.</p>
     {% endif %}
 
+    {% if not enough_invigilators %}
+        <tr>
+            <p><b>Since 75 students have been registered, please fill out the required fields for at least two invigilators</b></p>
+        </tr>
+        {% endif %}
+
     <!-- For "Confirm your school's language? -->
     <p> Please confirm your school's preferred language. </p>
     <select name = "language">
@@ -134,16 +140,6 @@
                     <td><input type ="text" class="invig_notes" name="inv_notes" value={{invigilator.notes}}></td>
                     <input type ="hidden" name="inv_registered_by" value ={{user.id}}> 
                 </tr>
-                {% elif forloop.counter == 2 and not enough_invigilators %} <!-- Enforce two invigilators if required -->
-                <tr>
-                    <td><input type="text" class="invig_firstname" name="inv_firstname" required value="{{invigilator.firstname}}"></td>
-                    <td><input type="text" class="invig_surname" name="inv_surname" required value="{{invigilator.surname}}"></td>
-                    <td><input type ="text" class="invig_phone_primary" name="inv_phone_primary" required value="{{invigilator.phone_primary}}"></td>                    
-                    <td><input type ="text"  class="invig_phone_alt" name="inv_phone_alt" value="{{invigilator.phone_alt}}"></td>
-                    <td><input type ="text" class="invig_mail" name="inv_email" required value={{invigilator.email|lower}}></td>
-                    <td><input type ="text" class="invig_notes" name="inv_notes" value={{invigilator.notes}}></td>
-                    <input type ="hidden" name="inv_registered_by" value ={{user.id}}> 
-                </tr> 
                 {% else %}
                 <tr>
                     <td><input type="text" class="invig_firstname" name="inv_firstname" value="{{invigilator.firstname}}"></td>
@@ -160,26 +156,6 @@
 
             {%for invigilator in invigilator_range%}
                 {% if invigilator_list|length == 0 and forloop.first %}
-                <tr>
-                    <td><input type="text" class="invig_firstname" required name="inv_firstname"></td>
-                    <td><input type="text" class="invig_surname" required name="inv_surname"></td>
-                    <td><input type ="text" class="invig_phone_primary" required name="inv_phone_primary"></td>
-                    <td><input type ="text" class="invig_phone_alt" name="inv_phone_alt"></td>
-                    <td><input type ="text" class="invig_mail" required name="inv_email"></td>
-                    <td><input type ="text" class="invig_notes" name="inv_notes"></td>
-                    <input type ="hidden" name="inv_registered_by" value ={{user.id}}>
-                </tr>
-                {% elif invigilator_list|length == 0 and forloop.counter == 2 and not enough_invigilators %}
-                <tr>
-                    <td><input type="text" class="invig_firstname" required name="inv_firstname"></td>
-                    <td><input type="text" class="invig_surname" required name="inv_surname"></td>
-                    <td><input type ="text" class="invig_phone_primary" required name="inv_phone_primary"></td>
-                    <td><input type ="text" class="invig_phone_alt" name="inv_phone_alt"></td>
-                    <td><input type ="text" class="invig_mail" required name="inv_email"></td>
-                    <td><input type ="text" class="invig_notes" name="inv_notes"></td>
-                    <input type ="hidden" name="inv_registered_by" value ={{user.id}}>
-                </tr>
-                {% elif invigilator_list|length == 1 and forloop.counter == 1 and not enough_invigilators %}
                 <tr>
                     <td><input type="text" class="invig_firstname" required name="inv_firstname"></td>
                     <td><input type="text" class="invig_surname" required name="inv_surname"></td>

--- a/uctMaths/apps/competition/interface/newstudents.html
+++ b/uctMaths/apps/competition/interface/newstudents.html
@@ -57,7 +57,7 @@
                 <td><input type ="text" class="resp_cell" name="rt_phone_cell" value="{{responsible_teacher.phone_cell}}"></td>
                 <td><input id="rmail" class="resp_mail_school" type ="text" name="rt_email_school" required value={{responsible_teacher.email_school|lower}}></td>
                 <td><input id="rmail" class="resp_mail_personal" type ="text" name="rt_email_personal" value={{responsible_teacher.email_personal|lower}}></td>
-                <input type ="hidden" name="rt_registered_by" value ={{ user.id }} > <!-- Remove space? -->
+                <input type ="hidden" name="rt_registered_by" value ={{user.id}}>
             </tr>
         </table>
     </div>
@@ -88,7 +88,7 @@
                 <td><input type ="text" class="alt_resp_cell" name="art_phone_cell" value="{{alt_responsible_teacher.phone_cell}}"></td>
                 <td><input id="rmail" class="alt_resp_mail_school" type ="text" name="art_email_school" required value={{alt_responsible_teacher.email_school|lower}}></td>
                 <td><input id="rmail" class="alt_resp_mail_personal" type ="text" name="art_email_personal" value={{alt_responsible_teacher.email_personal|lower}}></td>
-                <input type ="hidden" name="alt_rt_registered_by" value ={{ user.id }} > <!-- Remove space? -->
+                <input type ="hidden" name="alt_rt_registered_by" value ={{user.id}}>
             </tr>
         </table>
     </div>
@@ -100,7 +100,14 @@
     <div>
         <h1>Register Invigilators</h1>
         <p>Please note that every school must send at least 1 Invigilator and that if the responsible teacher is going to invigilate kindly add your name to the Invigilators list. <br> Schools which send a full entry of {{maxEntries}} participants must send at least two invigilators.
- <br><i> All fields marked with an <b>asterisk (*) must be filled for an entry to be valid.</b></i></p>
+        <br><i> All fields marked with an <b>asterisk (*) must be filled for an entry to be valid.</b></i><p>
+        {% if not enough_invigilators %}
+        <tr>
+            <p><b>Please enter 2 invigilators</b></p>
+        </tr>
+        {% endif %}
+        
+
         <p> {{ ierror }} </p>
         {% csrf_token %}
 
@@ -125,24 +132,34 @@
                     <td><input type ="text"  class="invig_phone_alt" name="inv_phone_alt" value="{{invigilator.phone_alt}}"></td>
                     <td><input type ="text" class="invig_mail" name="inv_email" required value={{invigilator.email|lower}}></td>
                     <td><input type ="text" class="invig_notes" name="inv_notes" value={{invigilator.notes}}></td>
-                    <input type ="hidden" name="inv_registered_by" value ={{ user.id }} > <!-- Remove space? -->
+                    <input type ="hidden" name="inv_registered_by" value ={{user.id}}> 
                 </tr>
+                {% elif forloop.counter == 2 and not enough_invigilators %} <!-- Enforce two invigilators if required -->
+                <tr>
+                    <td><input type="text" class="invig_firstname" name="inv_firstname" required value="{{invigilator.firstname}}"></td>
+                    <td><input type="text" class="invig_surname" name="inv_surname" required value="{{invigilator.surname}}"></td>
+                    <td><input type ="text" class="invig_phone_primary" name="inv_phone_primary" required value="{{invigilator.phone_primary}}"></td>                    
+                    <td><input type ="text"  class="invig_phone_alt" name="inv_phone_alt" value="{{invigilator.phone_alt}}"></td>
+                    <td><input type ="text" class="invig_mail" name="inv_email" required value={{invigilator.email|lower}}></td>
+                    <td><input type ="text" class="invig_notes" name="inv_notes" value={{invigilator.notes}}></td>
+                    <input type ="hidden" name="inv_registered_by" value ={{user.id}}> 
+                </tr> 
                 {% else %}
                 <tr>
                     <td><input type="text" class="invig_firstname" name="inv_firstname" value="{{invigilator.firstname}}"></td>
                     <td><input type="text" class="invig_surname" name="inv_surname" value="{{invigilator.surname}}"></td>
-                    <td><input type ="text" class="invig_phone_primary" name="inv_phone_primary" value="{{invigilator.phone_primary | cut:" "}}"></td>                    
+                    <td><input type ="text" class="invig_phone_primary" name="inv_phone_primary" value='{{invigilator.phone_primary | cut:" "}}'></td>                    
                     <td><input type ="text" class="invig_phone_alt" name="inv_phone_alt" value="{{invigilator.phone_alt}}"></td>
                     <td><input type ="text" class="invig_mail" name="inv_email" value={{invigilator.email|lower}}></td>
-                    <td><input type ="text" class="invig_notes" name="inv_notes" value={{invigilator.notes}}></td>
-                    <input type ="hidden" name="inv_registered_by" value ={{ user.id }} > <!-- Remove space? -->
+                    <td><input type ="text" class="invig_notes" name="inv_notes" value={{invigilator.notes}}></td>                        
+                    <input type ="hidden" name="inv_registered_by" value ={{user.id}}>
                 </tr>
                 {% endif %}
-
             {%endfor%}
             
+
             {%for invigilator in invigilator_range%}
-            {% if invigilator_list|length == 0 and forloop.first %}
+                {% if invigilator_list|length == 0 and forloop.first %}
                 <tr>
                     <td><input type="text" class="invig_firstname" required name="inv_firstname"></td>
                     <td><input type="text" class="invig_surname" required name="inv_surname"></td>
@@ -150,9 +167,29 @@
                     <td><input type ="text" class="invig_phone_alt" name="inv_phone_alt"></td>
                     <td><input type ="text" class="invig_mail" required name="inv_email"></td>
                     <td><input type ="text" class="invig_notes" name="inv_notes"></td>
-                    <input type ="hidden" name="inv_registered_by" value ={{ user.id }} > <!-- Remove space? -->
+                    <input type ="hidden" name="inv_registered_by" value ={{user.id}}>
                 </tr>
-            {% else %}
+                {% elif invigilator_list|length == 0 and forloop.counter == 2 and not enough_invigilators %}
+                <tr>
+                    <td><input type="text" class="invig_firstname" required name="inv_firstname"></td>
+                    <td><input type="text" class="invig_surname" required name="inv_surname"></td>
+                    <td><input type ="text" class="invig_phone_primary" required name="inv_phone_primary"></td>
+                    <td><input type ="text" class="invig_phone_alt" name="inv_phone_alt"></td>
+                    <td><input type ="text" class="invig_mail" required name="inv_email"></td>
+                    <td><input type ="text" class="invig_notes" name="inv_notes"></td>
+                    <input type ="hidden" name="inv_registered_by" value ={{user.id}}>
+                </tr>
+                {% elif invigilator_list|length == 1 and forloop.counter == 1 and not enough_invigilators %}
+                <tr>
+                    <td><input type="text" class="invig_firstname" required name="inv_firstname"></td>
+                    <td><input type="text" class="invig_surname" required name="inv_surname"></td>
+                    <td><input type ="text" class="invig_phone_primary" required name="inv_phone_primary"></td>
+                    <td><input type ="text" class="invig_phone_alt" name="inv_phone_alt"></td>
+                    <td><input type ="text" class="invig_mail" required name="inv_email"></td>
+                    <td><input type ="text" class="invig_notes" name="inv_notes"></td>
+                    <input type ="hidden" name="inv_registered_by" value ={{user.id}}>
+                </tr>
+                {% else %}
                 <tr>
                     <td><input type="text" class="invig_firstname" name="inv_firstname"></td>
                     <td><input type="text" class="invig_surname" name="inv_surname"></td>
@@ -160,11 +197,10 @@
                     <td><input type ="text" class="invig_phone_alt" name="inv_phone_alt"></td>
                     <td><input type ="text" class="invig_mail" name="inv_email"></td>
                     <td><input type ="text" class="invig_notes" name="inv_notes"></td>
-                    <input type ="hidden" name="inv_registered_by" value ={{ user.id }} > <!-- Remove space? -->
+                    <input type ="hidden" name="inv_registered_by" value ={{user.id}}>
                 </tr>
-            {% endif %}
-
-            {%endfor%}
+                {% endif %}
+            {% endfor %}
 
         </table>
 
@@ -214,7 +250,7 @@
                     <td><input type="text" class="st_firstname" name="firstname" value="{{student.firstname}}"></td>
                     <td><input type="text" class="st_surname" name="surname" value="{{student.surname}}"></td>
                     <input type='hidden' name='grade' value='{{grade}}'>
-                    <input type ="hidden" name="registered_by" value ={{ user.id }} > <!-- Remove space? -->
+                    <input type ="hidden" name="registered_by" value ={{user.id}}>
                 </tr>
                 {%endfor%}
             {%endif%}
@@ -227,7 +263,7 @@
                   <td><input type="text" class="st_firstname" name="firstname"></td>
                   <td><input type="text" class="st_surname" name="surname"></td>
                   <input type='hidden' name='grade' value='{{grade}}'>
-                  <input type ="hidden" name="registered_by" value ={{ user.id }} > <!-- Remove space? -->
+                  <input type ="hidden" name="registered_by" value ={{user.id}}>
                 </tr>
                 {%endfor%}
             {%endif%}

--- a/uctMaths/apps/competition/interface/newvenues.html
+++ b/uctMaths/apps/competition/interface/newvenues.html
@@ -34,7 +34,7 @@
                     </select>
                 </td>
                 <td><input type ="text" name="pairs"></td>
-                <input type ="hidden" name="registered_by" value ={{ user.id }} > <!-- Remove space? -->
+                <input type ="hidden" name="registered_by" value ={{user.id}} > <!-- Remove space? -->
 
             </tr>
             {%endfor%}

--- a/uctMaths/apps/competition/interface/printer_entry.html
+++ b/uctMaths/apps/competition/interface/printer_entry.html
@@ -12,7 +12,7 @@
                         <td>
                             <table width="165">
                                 <tr>
-                                    <th align="left" valign="center">Grade:</th>
+                                    <th align="left" valign="middle">Grade:</th>
                                     <th align="center"><b>8</b></th>
                                     <th align="center"><b>9</b></th>
                                     <th align="center"><b>10</b></th>

--- a/uctMaths/apps/competition/views.py
+++ b/uctMaths/apps/competition/views.py
@@ -366,20 +366,19 @@ def newstudents(request):
                 query.save()
                 num_individuals += 1
 
-            #update view after new entries are added to the table
+            #Update data that is pre-fetched to populate the school form so no data is lossed upon failed form submission
             student_list = SchoolStudent.objects.filter(school = assigned_school)
-            individual_list, pair_list = compadmin.processGrade(student_list) #processGrade is defined below this method
-            entries_per_grade = {} #Dictionary with grade:range(...)
+            individual_list, pair_list = compadmin.processGrade(student_list)
+            entries_per_grade = {}
             pairs_per_grade = {}
             for grade in range(8,13):
                 entries_per_grade[grade] = range(compadmin.admin_number_of_individuals() - len(individual_list[grade]))
-                #Place the "Previously Selected" number of pairs at the top of the list (So it appears as a default)
                 pairs_per_grade[grade] = [pair_list[grade]]
                 pairs_per_grade[grade].extend([i for i in range(0, compadmin.admin_number_of_pairs() + 1) if i != pair_list[grade]])
 
             if 'submit_form' in request.POST: #Send confirmation email and continue
                 enoughInvigilators.checkEnoughInvigilators(num_invigilators, num_individuals, num_pairs)
-                if enoughInvigilators.enoughInvigilators:
+                if enoughInvigilators.enoughInvigilators: #Only proceed with submission if enough invigilators are entered
                     assigned_school.entered=1 #The school has made an entry
                     assigned_school.save()
                     #The school has made an entry
@@ -456,20 +455,19 @@ class enoughInvigilators():
     enoughInvigilators=True
         
     def checkEnoughInvigilators(num_invigilators, num_individuals, num_pairs):
+        """
+        Returns false only when there are less than two invigilators but maximum number of students entered.
+        In this case there are not enough invigilators entered and user should be prompted to add more.
+        """
+
         if num_invigilators>=2:
             enoughInvigilators.enoughInvigilators=True
             return
 
-        print("pairs")
-        print(num_pairs)
-        print(compadmin.admin_number_of_pairs())
         if num_pairs<(5*compadmin.admin_number_of_pairs()):
             enoughInvigilators.enoughInvigilators=True
             return
             
-        print("indivs")
-        print(num_individuals)
-        print(compadmin.admin_number_of_individuals())
         if num_individuals<(5*compadmin.admin_number_of_individuals()):
             enoughInvigilators.enoughInvigilators=True
             return

--- a/uctMaths/apps/competition/views.py
+++ b/uctMaths/apps/competition/views.py
@@ -366,6 +366,17 @@ def newstudents(request):
                 query.save()
                 num_individuals += 1
 
+            #update view after new entries are added to the table
+            student_list = SchoolStudent.objects.filter(school = assigned_school)
+            individual_list, pair_list = compadmin.processGrade(student_list) #processGrade is defined below this method
+            entries_per_grade = {} #Dictionary with grade:range(...)
+            pairs_per_grade = {}
+            for grade in range(8,13):
+                entries_per_grade[grade] = range(compadmin.admin_number_of_individuals() - len(individual_list[grade]))
+                #Place the "Previously Selected" number of pairs at the top of the list (So it appears as a default)
+                pairs_per_grade[grade] = [pair_list[grade]]
+                pairs_per_grade[grade].extend([i for i in range(0, compadmin.admin_number_of_pairs() + 1) if i != pair_list[grade]])
+
             if 'submit_form' in request.POST: #Send confirmation email and continue
                 enoughInvigilators.checkEnoughInvigilators(num_invigilators, num_individuals, num_pairs)
                 if enoughInvigilators.enoughInvigilators:
@@ -406,6 +417,12 @@ def newstudents(request):
     code = full[1].strip()
     city = full[2].strip()
 
+    student_list = SchoolStudent.objects.filter(school = assigned_school)
+    individual_list, pair_list = compadmin.processGrade(student_list) #processGrade is defined below this method
+    entries_per_grade = {} #Dictionary with grade:range(...)
+    for grade in range(8,13):
+        entries_per_grade[grade] = range(compadmin.admin_number_of_individuals() - len(individual_list[grade]))
+
     c = {'type':'Students',
         'schooln':assigned_school,
         'language_options':language_selection,
@@ -445,13 +462,15 @@ class enoughInvigilators():
 
         print("pairs")
         print(num_pairs)
-        if num_pairs<25:
+        print(compadmin.admin_number_of_pairs())
+        if num_pairs<(5*compadmin.admin_number_of_pairs()):
             enoughInvigilators.enoughInvigilators=True
             return
             
         print("indivs")
         print(num_individuals)
-        if num_individuals<25:
+        print(compadmin.admin_number_of_individuals())
+        if num_individuals<(5*compadmin.admin_number_of_individuals()):
             enoughInvigilators.enoughInvigilators=True
             return
 

--- a/uctMaths/apps/competition/views.py
+++ b/uctMaths/apps/competition/views.py
@@ -456,11 +456,17 @@ class enoughInvigilators():
         
     def checkEnoughInvigilators(num_invigilators, num_individuals, num_pairs):
         """
-        Returns false only when there are less than two invigilators but maximum number of students entered.
+        Sets enoughtInvigilators to false only when: 
+        the competiton has invigilator AND
+        there are less than two invigilators but maximum number of students entered.
         In this case there are not enough invigilators entered and user should be prompted to add more.
         """
 
-        if num_invigilators>=2:
+        if not compadmin.competition_has_invigilator():
+            enoughInvigilators.enoughInvigilators=True
+            return
+        
+        if num_invigilators>=2 or not compadmin.competition_has_invigilator():
             enoughInvigilators.enoughInvigilators=True
             return
 

--- a/uctMaths/apps/competition/views.py
+++ b/uctMaths/apps/competition/views.py
@@ -233,7 +233,6 @@ def newstudents(request):
         pairs_per_grade[grade].extend([i for i in range(0, compadmin.admin_number_of_pairs() + 1) if i != pair_list[grade]])
 
     if request.method == 'POST':  # If the form has been submitted...
-
         form = (request.POST) # A form bound to the POST data
 
         #Delete all previously stored information
@@ -243,7 +242,7 @@ def newstudents(request):
             assigned_school.language = form.getlist('language','')[0]
             assigned_school.phone = form.getlist('school_number','')[0]
             assigned_school.save()
-
+                
             #Register a single responsible teacher (assigned to that school)
             rtschool = assigned_school #School.objects.get(pk=int(form.getlist('school','')[0]))
             rtfirstname = form.getlist('rt_firstname','')[0]
@@ -256,8 +255,8 @@ def newstudents(request):
 
             #rtregistered_by =  User.objects.get(pk=int(form.getlist('rt_registered_by','')[0]))
             rt_query = ResponsibleTeacher(firstname = rtfirstname , surname = rtsurname, phone_primary = rtphone_primary,
-                                      phone_alt = rtphone_alt, phone_cell=rtphone_cell, school = rtschool,
-                                      email_school = rtemail_school, email_personal=rtemail_personal, is_primary = True)
+                                        phone_alt = rtphone_alt, phone_cell=rtphone_cell, school = rtschool,
+                                        email_school = rtemail_school, email_personal=rtemail_personal, is_primary = True)
 
             #Delete responsible teacher before saving the new one
             for rt in responsible_teacher:
@@ -279,8 +278,8 @@ def newstudents(request):
 
             #rtregistered_by =  User.objects.get(pk=int(form.getlist('rt_registered_by','')[0]))
             art_query = ResponsibleTeacher(firstname = artfirstname , surname = artsurname, phone_primary = artphone_primary,
-                                      phone_alt = artphone_alt, phone_cell=artphone_cell, school = artschool,
-                                      email_school = artemail_school, email_personal=artemail_personal, is_primary = False)
+                                        phone_alt = artphone_alt, phone_cell=artphone_cell, school = artschool,
+                                        email_school = artemail_school, email_personal=artemail_personal, is_primary = False)
 
             #Delete responsible teacher before saving the new one
             for art in alt_responsible_teacher:
@@ -290,16 +289,17 @@ def newstudents(request):
             art_query.reference=art_query.id
             art_query.save()
 
+            num_pairs = 0
             #Registering per grade
             for grade in range (8,13):
-                  #Registering the different pairs
-                  #Information is set to null, only school name is given and reference
-                  #Reference if the ID of the first person in the pair
+                #Registering the different pairs
+                #Information is set to null, only school name is given and reference
+                #Reference if the ID of the first person in the pair
 
-                  if compadmin.admin_number_of_pairs() == 0:
+                if compadmin.admin_number_of_pairs() == 0:
                     break
 
-                  for p in range(int(form.getlist("pairs",'')[grade-8])):
+                for p in range(int(form.getlist("pairs",'')[grade-8])):
                         firstname = 'Pair/Paar'
                         surname = str(grade)+chr(65 + p)   # Maps 0, 1, 2, 3... to A, B, C...
                         pair_number = 51 + p
@@ -310,9 +310,11 @@ def newstudents(request):
                         location = assigned_school.location
 
                         query = SchoolStudent(firstname=firstname , surname=surname, language=language, reference=reference,
-                                school=school, grade=grade, paired=paired, location=location)
+                                    school=school, grade=grade, paired=paired, location=location)
                         query.save()
+                        num_pairs += 1
 
+            num_invigilators = 0
             #Add invigilator information
             for invigilator in invigilator_list:
                 invigilator.delete()
@@ -338,7 +340,9 @@ def newstudents(request):
                     query = Invigilator(school=school, firstname=ifirstname, surname=isurname, location=location,
                                     phone_primary=iphone_primary, phone_alt=iphone_alt, email=iemail, notes=inotes)
                     query.save()
+                    num_invigilators += 1
 
+            num_individuals = 0
             #Registering students, maximum number of students 25
             #Returns an error if information entered incorrectly
 
@@ -358,19 +362,22 @@ def newstudents(request):
                 location = assigned_school.location
 
                 query = SchoolStudent(firstname=firstname, surname=surname, language=language, reference=reference,
-                        school=school, grade=grade, paired=paired, location=location)
+                            school=school, grade=grade, paired=paired, location=location)
                 query.save()
+                num_individuals += 1
 
             if 'submit_form' in request.POST: #Send confirmation email and continue
-                assigned_school.entered=1 #The school has made an entry
-                assigned_school.save()
-                 #The school has made an entry
-                try:
-                    confirmation.send_confirmation(request, assigned_school, cc_admin=True)
-                    return HttpResponseRedirect('../submitted/')
-                except Exception as e:
-                    print(e)
-                    return HttpResponseRedirect('../submitted/')
+                enoughInvigilators.checkEnoughInvigilators(num_invigilators, num_individuals, num_pairs)
+                if enoughInvigilators.enoughInvigilators:
+                    assigned_school.entered=1 #The school has made an entry
+                    assigned_school.save()
+                    #The school has made an entry
+                    try:
+                        confirmation.send_confirmation(request, assigned_school, cc_admin=True)
+                        return HttpResponseRedirect('../submitted/')
+                    except Exception as e:
+                        print(e)
+                        return HttpResponseRedirect('../submitted/')
             else:
                 print('This should not happen')
 
@@ -410,6 +417,7 @@ def newstudents(request):
         'max_num_pairs': compadmin.admin_number_of_pairs(),
         'entries_per_grade':entries_per_grade,
         'invigilator_list': invigilator_list,
+        'enough_invigilators': enoughInvigilators.enoughInvigilators,
         'entries_open': compadmin.isOpen() or request.user.is_staff,
         'grades':range(8,13), 
         'error':error,
@@ -426,6 +434,29 @@ def newstudents(request):
     c.update(csrf(request))
     #TODO Cancel button (Go back to 'Entry Review' - if possible)
     return render_to_response(request, 'newstudents.html', c)
+
+class enoughInvigilators():
+    enoughInvigilators=True
+        
+    def checkEnoughInvigilators(num_invigilators, num_individuals, num_pairs):
+        if num_invigilators>=2:
+            enoughInvigilators.enoughInvigilators=True
+            return
+
+        print("pairs")
+        print(num_pairs)
+        if num_pairs<25:
+            enoughInvigilators.enoughInvigilators=True
+            return
+            
+        print("indivs")
+        print(num_individuals)
+        if num_individuals<25:
+            enoughInvigilators.enoughInvigilators=True
+            return
+
+        enoughInvigilators.enoughInvigilators=False
+
 
 def correctCapitals(input_name):
     

--- a/uctMaths/apps/j5auth/j5account/forms.py
+++ b/uctMaths/apps/j5auth/j5account/forms.py
@@ -16,7 +16,7 @@ from ..utils import (email_address_exists, get_user_model)
 
 from .models import EmailAddress
 from .utils import perform_login, send_email_confirmation, setup_user_email
-from .app_settings import AppSettings, app_settings
+from .app_settings import  app_settings
 from .adapter import get_adapter
 import collections
 


### PR DESCRIPTION
Added the following:

Answer sheets download as an attachment now rather than being opened in the browser first. This allows them to be downloaded as a PDF.

In the case when a competition has invigilators:
When a school registers the maximum number for students (75 students), They are forced to enter two invigilators.

When editing a venue, if any of the save buttons are clicked, then deallocated all students assigned to that venue.