### PR TITLE
Change pair count to be the number of pair teams, not the number of students writing as pairs

### DIFF
--- a/uctMaths/apps/competition/confirmation.py
+++ b/uctMaths/apps/competition/confirmation.py
@@ -4,6 +4,7 @@ from django.contrib.auth.decorators import login_required
 from .models import SchoolStudent, Invigilator, ResponsibleTeacher
 from django.core.mail import EmailMessage
 import datetime
+from math import ceil
 
 from . import compadmin #import the competition administrator (secretary's) email (to be CC'd in the
                  # confirmation email.
@@ -74,8 +75,10 @@ def print_students(student_list,width=40):
         for student in student_list:
             if student.paired: # Better pair condition logic for this!
                 pair_list[student.grade] += 1
-            else: 
+            else:
                 single_list[student.grade].append((student.firstname, student.surname))
+        for grade, num_students in pair_list.items():
+            pair_list[grade] = ceil(num_students/2)
 
     except IndexError: #If the user submitted an empty form
         print('Index Error (Confirmation email)')

--- a/uctMaths/apps/competition/views.py
+++ b/uctMaths/apps/competition/views.py
@@ -10,6 +10,7 @@ from .forms import StudentForm
 from .models import SchoolStudent, School, Invigilator, ResponsibleTeacher
 from django.core import exceptions
 from django.contrib.auth.decorators import login_required
+from math import ceil
 
 from . import confirmation
 from . import compadmin
@@ -113,13 +114,13 @@ def submitted(request):
     for i in range(8,13):
         grade_summary_text = 'Grade %d: %d individuals' % (i, len(grade_summary[i,False,'ALL']))
         if compadmin.admin_number_of_pairs() > 0:
-            grade_summary_text += " and %d pairs" % (len(grade_summary[i,True,'ALL']))
+            grade_summary_text += " and %d pairs" % (ceil(len(grade_summary[i, True, 'ALL']) / 2))
         school_summary_info.append(grade_summary_text)
-        count_pairs = count_pairs + len(grade_summary[i,True,'ALL'])
-        count_individuals = count_individuals + len(grade_summary[i,False,'ALL'])
-        
-    school_summary_statistics = 'You have successfully registered %d students' % (count_pairs*2+count_individuals)
-    
+        count_pairs = count_pairs + ceil(len(grade_summary[i, True, 'ALL']) / 2)
+        count_individuals = count_individuals + len(grade_summary[i, False, 'ALL'])
+
+    school_summary_statistics = 'You have successfully registered %d students' % (count_pairs * 2 + count_individuals)
+
     if compadmin.admin_number_of_pairs() > 0:
         school_summary_statistics += ' (%d individuals and %d pairs).' % (count_individuals, count_pairs)
 


### PR DESCRIPTION
A bug was reported by Hoerskool Labori when they registered. On the confirmation email, pairs were being reported at the number of students writing as pairs rather than the number of pair teams. This resulted in double-counting the pair students when reporting the total number of registered students. No idea how this hasn't been picked up before since it seems the code has been like this for at least 3 years.

Before the change:
- click on entry form
- fill in some data
- submit
- the confirmation email sent:
![image](https://github.com/user-attachments/assets/fe3afa7c-a5d7-4fff-913d-b71ef991ab5c)
- the pdf in the confirmation email:
![image](https://github.com/user-attachments/assets/7d98f984-6b6c-4650-8a55-d229e098ba17)
- the summary on the browser page:
![image](https://github.com/user-attachments/assets/391ee8ea-8370-4877-8d09-d4e428b08e56)


After the change:
- the confirmation email sent:
![image](https://github.com/user-attachments/assets/26502dec-2306-4029-8e1d-68a2fe5b2525)
- the pdf in the confirmation email:
![image](https://github.com/user-attachments/assets/6669955f-8ecb-40ff-ba0b-a365c161ad1b)
- the summary on the browser page:
![image](https://github.com/user-attachments/assets/02665e4f-0a79-4970-9f2f-4efe6c372b42)
