### PR TITLE
Revert "Change pair count to be the number of pair teams, not the number of students writing as pairs"

### DIFF
--- a/uctMaths/apps/competition/compadmin.py
+++ b/uctMaths/apps/competition/compadmin.py
@@ -26,7 +26,6 @@ from django.template.context_processors import csrf
 from xhtml2pdf import pisa
 from django.template.loader import get_template
 from .models import LOCATIONS
-from math import ceil
 
 
 import shutil
@@ -198,12 +197,10 @@ def processGrade(student_list):
     try:
         for student in student_list:
             if student.paired:
-                #Count number of pairs (i.e. teams of 2) for each grade
-                pair_list[student.grade]+=1
-            else:
+                #Count number of pairs for each grade
+                pair_list[student.grade]+=1 
+            else: 
                 individual_list[student.grade].append(student)
-        for grade, num_students in pair_list.items():
-            pair_list[grade] = ceil(num_students / 2)  # num_pairs
     except IndexError:
         print('Index Error')
 
@@ -963,9 +960,9 @@ def school_summary_sheet(school_list, wb_sheet, rank_extend=False):
             count_individuals = 0
             count_pairs = 0
 
-            for i in range(8, 13):
-                count_pairs = count_pairs + ceil(len(grade_summary[i, True, 'ALL']) / 2)
-                count_individuals = count_individuals + len(grade_summary[i, False, 'ALL'])
+            for i in range(8,13):
+                count_pairs = count_pairs + len(grade_summary[i,True,'ALL'])
+                count_individuals = count_individuals + len(grade_summary[i,False,'ALL'])
 
             cell_row_offset = cell_row_offset + 1
             wb_sheet.write(cell_row_offset,0,str(school_obj.name))
@@ -1402,16 +1399,15 @@ def generate_school_confirmation(request, school_list):
         grade_summary = gradeBucket(student_list) #Bin into categories (Grade, Is Paired, Location)
         count_individuals = 0
         count_pairs = 0
-
-        for i in range(8, 13):
-            count_pairs = count_pairs + ceil(len(grade_summary[i, True, 'ALL']) / 2)
-            count_individuals = count_individuals + len(grade_summary[i, False, 'ALL'])
-
-        invigilator_list = Invigilator.objects.filter(school=assigned_school)
-        responsible_teacher = ResponsibleTeacher.objects.filter(school=assigned_school).filter(is_primary=True)
-        alt_responsible_teacher = ResponsibleTeacher.objects.filter(school=assigned_school).filter(is_primary=False)
-        timestamp = str(
-            datetime.datetime.now(tz=pytz.timezone("Africa/Johannesburg")).strftime('%d %B %Y at %H:%M (local time)'))
+        
+        for i in range(8,13):
+            count_pairs = count_pairs + len(grade_summary[i,True,'ALL'])
+            count_individuals = count_individuals + len(grade_summary[i,False,'ALL'])
+        
+        invigilator_list = Invigilator.objects.filter(school = assigned_school)
+        responsible_teacher = ResponsibleTeacher.objects.filter(school = assigned_school).filter(is_primary = True)
+        alt_responsible_teacher = ResponsibleTeacher.objects.filter(school = assigned_school).filter(is_primary = False)
+        timestamp = str(datetime.datetime.now(tz=pytz.timezone("Africa/Johannesburg")).strftime('%d %B %Y at %H:%M (local time)'))
         year = str(datetime.datetime.now(tz=pytz.timezone("Africa/Johannesburg")).strftime('%Y'))
         if responsible_teacher:
             responsible_teacher = responsible_teacher[0]

--- a/uctMaths/apps/competition/confirmation.py
+++ b/uctMaths/apps/competition/confirmation.py
@@ -4,7 +4,6 @@ from django.contrib.auth.decorators import login_required
 from .models import SchoolStudent, Invigilator, ResponsibleTeacher
 from django.core.mail import EmailMessage
 import datetime
-from math import ceil
 
 from . import compadmin #import the competition administrator (secretary's) email (to be CC'd in the
                  # confirmation email.
@@ -75,10 +74,8 @@ def print_students(student_list,width=40):
         for student in student_list:
             if student.paired: # Better pair condition logic for this!
                 pair_list[student.grade] += 1
-            else:
+            else: 
                 single_list[student.grade].append((student.firstname, student.surname))
-        for grade, num_students in pair_list.items():
-            pair_list[grade] = ceil(num_students/2)
 
     except IndexError: #If the user submitted an empty form
         print('Index Error (Confirmation email)')

--- a/uctMaths/apps/competition/views.py
+++ b/uctMaths/apps/competition/views.py
@@ -10,7 +10,6 @@ from .forms import StudentForm
 from .models import SchoolStudent, School, Invigilator, ResponsibleTeacher
 from django.core import exceptions
 from django.contrib.auth.decorators import login_required
-from math import ceil
 
 from . import confirmation
 from . import compadmin
@@ -114,13 +113,13 @@ def submitted(request):
     for i in range(8,13):
         grade_summary_text = 'Grade %d: %d individuals' % (i, len(grade_summary[i,False,'ALL']))
         if compadmin.admin_number_of_pairs() > 0:
-            grade_summary_text += " and %d pairs" % (ceil(len(grade_summary[i, True, 'ALL']) / 2))
+            grade_summary_text += " and %d pairs" % (len(grade_summary[i,True,'ALL']))
         school_summary_info.append(grade_summary_text)
-        count_pairs = count_pairs + ceil(len(grade_summary[i, True, 'ALL']) / 2)
-        count_individuals = count_individuals + len(grade_summary[i, False, 'ALL'])
-
-    school_summary_statistics = 'You have successfully registered %d students' % (count_pairs * 2 + count_individuals)
-
+        count_pairs = count_pairs + len(grade_summary[i,True,'ALL'])
+        count_individuals = count_individuals + len(grade_summary[i,False,'ALL'])
+        
+    school_summary_statistics = 'You have successfully registered %d students' % (count_pairs*2+count_individuals)
+    
     if compadmin.admin_number_of_pairs() > 0:
         school_summary_statistics += ' (%d individuals and %d pairs).' % (count_individuals, count_pairs)
 


### PR DESCRIPTION
Reverts j5int/uct-maths-competition#92

A bug was introduced in a previous pr that resulted in every pair record being duplicated on registration. Once that bug is fixed, the pair count will be correct again. 