### PR TITLE
Fix duplicate pair creation on registration bug

### DIFF
--- a/uctMaths/apps/competition/views.py
+++ b/uctMaths/apps/competition/views.py
@@ -314,24 +314,6 @@ def newstudents(request):
             #Update data that is pre-fetched to populate the school form so no data is lossed upon failed form submission
             alt_responsible_teacher = ResponsibleTeacher.objects.filter(school = assigned_school).filter(is_primary = False)
 
-            num_pairs = 0
-            for grade in range(8, 13):
-
-                for p in range(int(form.getlist("pairs", '')[grade - 8])):
-                    firstname = 'Pair/Paar'
-                    surname = str(grade) + chr(65 + p)  # Maps 0, 1, 2, 3... to A, B, C...
-                    pair_number = 51 + p
-                    language = form.getlist('language', '')[0]
-                    school = assigned_school
-                    reference = '%3s%2s%2s' % (str(school.id).zfill(3), str(grade).zfill(2), str(pair_number).zfill(2))
-                    paired = True
-                    location = 'CPT'  # all students write in CPT
-
-                    query = SchoolStudent(firstname=firstname, surname=surname, language=language, reference=reference,
-                                          school=school, grade=grade, paired=paired, location=location)
-                    query.save()
-                    num_pairs += 1
-
             num_invigilators = 0
             # Add invigilator information
             for invigilator in invigilator_list:

--- a/uctMaths/apps/competition/views.py
+++ b/uctMaths/apps/competition/views.py
@@ -364,7 +364,7 @@ def newstudents(request):
                         school = assigned_school
                         reference = '%3s%2s%2s' % (str(school.id).zfill(3), str(grade).zfill(2), str(pair_number).zfill(2))
                         paired = True
-                        location = assigned_school.location
+                        location = 'CPT' #all students write in CPT
 
                         query = SchoolStudent(firstname=firstname , surname=surname, language=language, reference=reference,
                                     school=school, grade=grade, paired=paired, location=location)


### PR DESCRIPTION
As a result of a merge conflict which was resolved incorrectly, https://github.com/j5int/uct-maths-competition/commit/80750f358ec7258dc18002b7f9897b7dea43ff64, we had a duplicate piece of code which resulted in duplicate pair entries being created on registration. This PR removes the duplicate code. 

<img width="1147" height="706" alt="image" src="https://github.com/user-attachments/assets/1a730279-005e-4dc1-82fc-905523b1c329" />


Register 2 Gr 8 pairs and 1 Gr 9 pair (plus 5 Gr 8 indivs) for a school.
<img width="821" height="780" alt="image" src="https://github.com/user-attachments/assets/249e5b1c-ec9f-4b35-a5ce-cdbc3ed87bd4" />

Before fix:
- pairs double counted

<img width="597" height="377" alt="image" src="https://github.com/user-attachments/assets/ac0c29f9-479b-4523-91bb-961a4b24d4ff" />

- duplicate entries for pairs created 

<img width="950" height="450" alt="image" src="https://github.com/user-attachments/assets/4dadbc58-46fa-48a3-bb3f-c1e3a77f3f90" />


With fix: 
- correct number of students entered reported

<img width="538" height="256" alt="image" src="https://github.com/user-attachments/assets/3726fe78-4f81-4d00-917a-2c206372012d" />

- only 1 pair entry created for entered pair

<img width="940" height="364" alt="image" src="https://github.com/user-attachments/assets/23c734fc-1fd9-4b1f-8f2b-d2d9a69b72cb" />
