### PR TITLE
Update pair answer sheet template

### DIFF
--- a/uctMaths/apps/competition/interface/pdf_templates/pair_as_template.html
+++ b/uctMaths/apps/competition/interface/pdf_templates/pair_as_template.html
@@ -57,7 +57,7 @@
             <tr style="border-width: 0px; line-height: 100%;">
                 <td style="width:250px" class="noborder"></td>
                 <td class="noborder">Answer Sheet / Antwoordvel</td>
-                 <td style= "line-height: 100%; text-align: right; font-size:12pt; font-family:'Univers',sans-serif; border-width: 0px;">PAIRS / PARE</td>
+                <td class="noborder">PAIRS / PARE</td>
               </tr>
         </table>
         <br/>
@@ -176,36 +176,37 @@
       <br>
 
 
-<table align = "center" width = 100% style=" font-size:11pt; font-family:'Univers',sans-serif; border-width: 0px; line-height: 150%;">
-  <tr style="border-width: 0px; line-height: 150%;">
-    <td width=50% style=
-    "border-right-width: 1px;
-     border-left-width: 0px; 
-     border-bottom-width: 0px;
-     border-top-width: 0px;
-     text-align: right;
-     padding-right: 9px;">
-             First name and surname &nbsp ................ &nbsp<br>
-                   School and grade &nbsp ................ &nbsp<br>
-                Gender: Male/Female &nbsp ................ &nbsp<br>
-       Language preference: Eng/Afr &nbsp ................ &nbsp<br>
-                     Postal address &nbsp ................ &nbsp<br>
-                              Email	&nbsp ................ &nbsp<br>
-         Please send me information &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp<br>
-                    about bursaries &nbsp YES / NO &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp<br>
-                             Signed &nbsp ................ &nbsp<br>
-      </td>
-    <td style="border-width: 0px; text-align: right; padding-right: 64px;">
-      Voornaam en van &nbsp	..................<br>
-      Skool en graad &nbsp	..................<br>
-      Geslag: Manlik/Vroulik &nbsp	..................<br>
-      Taalvoorkeur: Afr/Eng &nbsp	..................<br>
-      Posadres &nbsp	..................<br>
-      Epos &nbsp	..................<br>
-      Stuur asseblief vir my &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp<br>
-      inligting oor beurse &nbsp JA / NEE &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp <br>
-      Geteken &nbsp	..................<br>
-      </td>
+<table align = "center" width = 100% style=" font-size:11pt; font-family:'Univers',sans-serif; padding: 2px; border-width: 0px; line-height: 100%">
+  <tr style="border-width: 0px; line-height: 100%;">
+    <td width=50% style="border-width: 0px; text-align: right; padding-right: 5px;">First name and surname………………………………………………………</td>
+    <td width=50% style="border-width: 0px; text-align: left; padding-left: 5px;">………………………………………………………Voornaam en van</td>
+  </tr>
+  <tr style="border-width: 0px; line-height: 100%;">
+    <td width=50% style="border-width: 0px; text-align: right; padding-right: 5px;">School………………………………………………………</td>
+    <td width=50% style="border-width: 0px; text-align: left; padding-left: 5px;">………………………………………………………Skool</td>
+  </tr>
+  <tr style="border-width: 0px; line-height: 100%;">
+    <td width=50% style="border-width: 0px; text-align: right; padding-right: 5px;">Gender………………………………………………………</td>
+    <td width=50% style="border-width: 0px; text-align: left; padding-left: 5px;">………………………………………………………Geslag</td>
+  </tr>
+    <tr style="border-width: 0px; line-height: 100%;">
+    <td width=50% style="border-width: 0px; text-align: right; padding-right: 5px;">Language preference  &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp ENG / AFR &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp  &nbsp &nbsp </td>
+    <td width=50% style="border-width: 0px; text-align: left; padding-left: 5px;">  &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp ENG / AFR  &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp  &nbsp &nbsp 	Taalvoorkeur</td>
+  <tr style="border-width: 0px; line-height: 100%;">
+    <td width=50% style="border-width: 0px; text-align: right; padding-right: 5px;">Postal address………………………………………………………</td>
+    <td width=50% style="border-width: 0px; text-align: left; padding-left: 5px;">………………………………………………………Posadres</td>
+  </tr>
+  <tr style="border-width: 0px; line-height: 100%;">
+    <td width=50% style="border-width: 0px; text-align: right; padding-right: 5px;">Email………………………………………………………</td>
+    <td width=50% style="border-width: 0px; text-align: left; padding-left: 5px;">………………………………………………………Epos</td>
+  </tr>
+  <tr style="border-width: 0px; line-height: 100%;">
+    <td width=50% style="border-width: 0px; text-align: right; padding-right: 5px;"> Please send me information about bursaries &nbsp &nbsp  &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp YES / NO  &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp </td>
+    <td width=50% style="border-width: 0px; text-align: left; padding-left: 5px;">   &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp JA / NEE  &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp &nbsp Stuur asseblief vir my inligting oor beurse </td>
+  </tr>
+  <tr style="border-width: 0px; line-height: 100%;">
+    <td width=50% style="border-width: 0px; text-align: right; padding-right: 5px;">Signed………………………………………………………</td>
+    <td width=50% style="border-width: 0px; text-align: left; padding-left: 5px;">  ………………………………………………………Geteken</td>
   </tr>
 </table> 
 

--- a/uctMaths/apps/competition/reports.py
+++ b/uctMaths/apps/competition/reports.py
@@ -83,35 +83,44 @@ def send_answer_sheets(school, answer_sheet, cc_admin=False):
     output_string += UMC_header("Answer Sheets")
     output_string += 'Answer sheets for %s\n%s\n'%(school.name, UMC_datetime())
     recipient_list = [rteacher.email_school]
-    if cc_admin:
-        recipient_list.append(compadmin.admin_emailaddress())
-    send_email(
-        "(Do not reply) UCT Mathematics Competition %s Answer Sheets" % (school.name),
-        output_string,
-        'UCT Mathematics Competition <%s>'%(settings.DEFAULT_FROM_EMAIL),#from
-        [{"name": "%s" % (compadmin.get_answer_sheet_name(school)), "value": answer_sheet.getvalue(), "type": "application/pdf"}],
-        recipient_list
-    )
-
-    arteacher = ResponsibleTeacher.objects.filter(school=school.id).filter(is_primary=False)
-    if arteacher:
-        alt_output_string = 'Dear %s, \n\n' \
-                        'This email contains answer sheets for %s for the upcoming UCT Mathematics Competition. ' \
-                        'your students will write on. \n\n' \
-                        'Regards,\n\n' \
-                        'The UCT Mathematics Competition team'%(arteacher.firstname + " " + arteacher.surname, school.name)
-        alt_output_string += UMC_header("Answer Sheets")
-        alt_output_string += 'Answer sheets for %s\n%s\n'%(school.name, UMC_datetime())
-        recipient_list = [arteacher.email_school]
+    try:
         if cc_admin:
             recipient_list.append(compadmin.admin_emailaddress())
         send_email(
             "(Do not reply) UCT Mathematics Competition %s Answer Sheets" % (school.name),
-            alt_output_string,
+            output_string,
             'UCT Mathematics Competition <%s>'%(settings.DEFAULT_FROM_EMAIL),#from
             [{"name": "%s" % (compadmin.get_answer_sheet_name(school)), "value": answer_sheet.getvalue(), "type": "application/pdf"}],
             recipient_list
         )
+    except:
+        raise Exception(
+            f"Failed to send to primary responsible teacher for school: {school.name}.")
+    finally:
+        try:
+            arteacher = rteachers.filter(is_primary=False)[0]
+            if arteacher:
+
+                alt_output_string = 'Dear %s, \n\n' \
+                                'This email contains answer sheets for %s for the upcoming UCT Mathematics Competition. ' \
+                                'your students will write on. \n\n' \
+                                'Regards,\n\n' \
+                                'The UCT Mathematics Competition team'%(arteacher.firstname + " " + arteacher.surname, school.name)
+                alt_output_string += UMC_header("Answer Sheets")
+                alt_output_string += 'Answer sheets for %s\n%s\n'%(school.name, UMC_datetime())
+                recipient_list = [arteacher.email_school]
+                if cc_admin:
+                    recipient_list.append(compadmin.admin_emailaddress())
+                send_email(
+                    "(Do not reply) UCT Mathematics Competition %s Answer Sheets" % (school.name),
+                    alt_output_string,
+                    'UCT Mathematics Competition <%s>'%(settings.DEFAULT_FROM_EMAIL),#from
+                    [{"name": "%s" % (compadmin.get_answer_sheet_name(school)), "value": answer_sheet.getvalue(), "type": "application/pdf"}],
+                    recipient_list
+                )
+        except:
+            raise Exception(
+                f"Failed to send to alternate responsible teacher for school: {school.name}.")
 
 def send_grade_answer_sheets_to_organiser(pdf_attachment_filename):
     print("Emailing " + os.path.basename(pdf_attachment_filename) + " to organiser.")

--- a/uctMaths/apps/competition/reports.py
+++ b/uctMaths/apps/competition/reports.py
@@ -83,44 +83,35 @@ def send_answer_sheets(school, answer_sheet, cc_admin=False):
     output_string += UMC_header("Answer Sheets")
     output_string += 'Answer sheets for %s\n%s\n'%(school.name, UMC_datetime())
     recipient_list = [rteacher.email_school]
-    try:
+    if cc_admin:
+        recipient_list.append(compadmin.admin_emailaddress())
+    send_email(
+        "(Do not reply) UCT Mathematics Competition %s Answer Sheets" % (school.name),
+        output_string,
+        'UCT Mathematics Competition <%s>'%(settings.DEFAULT_FROM_EMAIL),#from
+        [{"name": "%s" % (compadmin.get_answer_sheet_name(school)), "value": answer_sheet.getvalue(), "type": "application/pdf"}],
+        recipient_list
+    )
+
+    arteacher = rteachers.filter(is_primary=False)[0]
+    if arteacher:
+        alt_output_string = 'Dear %s, \n\n' \
+                        'This email contains answer sheets for %s for the upcoming UCT Mathematics Competition. ' \
+                        'your students will write on. \n\n' \
+                        'Regards,\n\n' \
+                        'The UCT Mathematics Competition team'%(arteacher.firstname + " " + arteacher.surname, school.name)
+        alt_output_string += UMC_header("Answer Sheets")
+        alt_output_string += 'Answer sheets for %s\n%s\n'%(school.name, UMC_datetime())
+        recipient_list = [arteacher.email_school]
         if cc_admin:
             recipient_list.append(compadmin.admin_emailaddress())
         send_email(
             "(Do not reply) UCT Mathematics Competition %s Answer Sheets" % (school.name),
-            output_string,
+            alt_output_string,
             'UCT Mathematics Competition <%s>'%(settings.DEFAULT_FROM_EMAIL),#from
             [{"name": "%s" % (compadmin.get_answer_sheet_name(school)), "value": answer_sheet.getvalue(), "type": "application/pdf"}],
             recipient_list
         )
-    except:
-        raise Exception(
-            f"Failed to send to primary responsible teacher for school: {school.name}.")
-    finally:
-        try:
-            arteacher = rteachers.filter(is_primary=False)[0]
-            if arteacher:
-
-                alt_output_string = 'Dear %s, \n\n' \
-                                'This email contains answer sheets for %s for the upcoming UCT Mathematics Competition. ' \
-                                'your students will write on. \n\n' \
-                                'Regards,\n\n' \
-                                'The UCT Mathematics Competition team'%(arteacher.firstname + " " + arteacher.surname, school.name)
-                alt_output_string += UMC_header("Answer Sheets")
-                alt_output_string += 'Answer sheets for %s\n%s\n'%(school.name, UMC_datetime())
-                recipient_list = [arteacher.email_school]
-                if cc_admin:
-                    recipient_list.append(compadmin.admin_emailaddress())
-                send_email(
-                    "(Do not reply) UCT Mathematics Competition %s Answer Sheets" % (school.name),
-                    alt_output_string,
-                    'UCT Mathematics Competition <%s>'%(settings.DEFAULT_FROM_EMAIL),#from
-                    [{"name": "%s" % (compadmin.get_answer_sheet_name(school)), "value": answer_sheet.getvalue(), "type": "application/pdf"}],
-                    recipient_list
-                )
-        except:
-            raise Exception(
-                f"Failed to send to alternate responsible teacher for school: {school.name}.")
 
 def send_grade_answer_sheets_to_organiser(pdf_attachment_filename):
     print("Emailing " + os.path.basename(pdf_attachment_filename) + " to organiser.")


### PR DESCRIPTION
This PR fixes 2 problems:

1. There was a bug with sending to the secondary responsible teacher. It never succeeded. Now it should work. 
Before:
<img width="906" height="558" alt="image" src="https://github.com/user-attachments/assets/445b5755-50ea-4885-9048-2b72e04eed02" />
After:
<img width="1579" height="168" alt="image" src="https://github.com/user-attachments/assets/63d33fc0-3b0e-40c2-9269-eaf98569961c" />

2. Updated the pairs answer sheet template to include more space for student details. 
Before:
<img width="1097" height="759" alt="image" src="https://github.com/user-attachments/assets/a9b55d02-80ea-46ae-9d72-f785941769d2" />

After:
<img width="1080" height="769" alt="image" src="https://github.com/user-attachments/assets/116b9fb9-3793-4a94-b7be-717914f1e671" />

(Note, the PDF generator we use (xhtml2pdf/pisa) doesn't support CSS dotted borders, overflow: hidden, or whitespace: nowrap. This restricted the template solution we were able to come up with.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/j5int/uct-maths-competition/117)
<!-- Reviewable:end -->
