### PR TITLE
Fix upload results py2 -> py3 issue

### DIFF
--- a/uctMaths/apps/competition/compadmin_views.py
+++ b/uctMaths/apps/competition/compadmin_views.py
@@ -97,7 +97,7 @@ def handle_uploaded_file(inputf):
     for chunk in inputf.chunks():
         input_fstring += chunk.decode('utf-8','replace') #Replace accented characters with unicode equivalents
 
-    results = csv.DictReader(input_fstring)
+    results = csv.DictReader(io.StringIO(input_fstring))
 
     dne_list = [] #Hold "list of errors" to be placed on template. Called "Does Not Exist (DNE) list"
 


### PR DESCRIPTION
The input_fstring read in looks something like 'Reference,Score,Rank\r\n...' Without the io.StringIO wrapper, the first fieldname is extracted as 'R' instead of 'Reference'. 

Not sure how this would have worked last year 😅 But as far as I can tell, this would have been necessary ever since the py3 upgrade?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/j5int/uct-maths-competition/118)
<!-- Reviewable:end -->
